### PR TITLE
Assessment passmark and results refresh

### DIFF
--- a/src/components/NotificationModal.tsx
+++ b/src/components/NotificationModal.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { X, CheckCircle, AlertCircle, Info } from "lucide-react";
+
+interface NotificationModalProps {
+  isOpen: boolean;
+  type?: "success" | "error" | "info";
+  title?: string;
+  message: string;
+  onClose: () => void;
+}
+
+const NotificationModal: React.FC<NotificationModalProps> = ({
+  isOpen,
+  type = "success",
+  title,
+  message,
+  onClose,
+}) => {
+  if (!isOpen) return null;
+
+  const iconMap = {
+    success: <CheckCircle className="h-6 w-6 text-green-500" />,
+    error: <AlertCircle className="h-6 w-6 text-red-500" />,
+    info: <Info className="h-6 w-6 text-blue-500" />,
+  };
+
+  const bgColorMap = {
+    success: "bg-green-50 dark:bg-green-900/20",
+    error: "bg-red-50 dark:bg-red-900/20",
+    info: "bg-blue-50 dark:bg-blue-900/20",
+  };
+
+  const borderColorMap = {
+    success: "border-green-200 dark:border-green-800",
+    error: "border-red-200 dark:border-red-800",
+    info: "border-blue-200 dark:border-blue-800",
+  };
+
+  const defaultTitle = {
+    success: "Success",
+    error: "Error",
+    info: "Information",
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-6 border border-gray-200 dark:border-gray-700 animate-in fade-in-0 zoom-in-95 duration-200">
+        <div className="flex items-start gap-4">
+          <div className={`flex-shrink-0 ${bgColorMap[type]} ${borderColorMap[type]} rounded-full p-2 border-2`}>
+            {iconMap[type]}
+          </div>
+          <div className="flex-1">
+            <div className="flex items-center justify-between mb-2">
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+                {title || defaultTitle[type]}
+              </h2>
+              <button
+                onClick={onClose}
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                aria-label="Close"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <p className="text-gray-600 dark:text-gray-300 whitespace-pre-line">
+              {message}
+            </p>
+          </div>
+        </div>
+        <div className="flex justify-end mt-6">
+          <button
+            onClick={onClose}
+            className={`px-4 py-2 rounded-lg transition-colors font-medium ${
+              type === "success"
+                ? "bg-green-500 text-white hover:bg-green-600"
+                : type === "error"
+                ? "bg-red-500 text-white hover:bg-red-600"
+                : "bg-blue-500 text-white hover:bg-blue-600"
+            }`}
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationModal;

--- a/src/private/pages/publicContent/online-courses/forms/assessment-form.js
+++ b/src/private/pages/publicContent/online-courses/forms/assessment-form.js
@@ -35,6 +35,9 @@ export default function AssessmentForm({
   const [timeLimit, setTimeLimit] = useState(
     assessment?.timeLimit !== undefined ? assessment.timeLimit : 30
   );
+  const [passMark, setPassMark] = useState(
+    assessment?.passMark !== undefined ? assessment.passMark : 70
+  );
   const [questionBank, setQuestionBank] = useState(
     assessment?.questionBank || []
   );
@@ -68,6 +71,11 @@ export default function AssessmentForm({
       setName(assessment.name);
       setDescription(assessment.description);
       setQuestionsToPresent(assessment.questionsToPresent);
+      setShowAnswers(assessment.showAnswers !== undefined ? assessment.showAnswers : true);
+      setMaxRetries(assessment.maxRetries !== undefined ? assessment.maxRetries : 3);
+      setTimingMode(assessment.timingMode || "none");
+      setTimeLimit(assessment.timeLimit !== undefined ? assessment.timeLimit : 30);
+      setPassMark(assessment.passMark !== undefined ? assessment.passMark : 70);
 
       // Load existing questions from API if available, otherwise use assessment.questionBank
       if (existingQuestions.length > 0) {
@@ -95,6 +103,11 @@ export default function AssessmentForm({
       setName("");
       setDescription("");
       setQuestionsToPresent(0);
+      setShowAnswers(true);
+      setMaxRetries(3);
+      setTimingMode("none");
+      setTimeLimit(30);
+      setPassMark(70);
       setQuestionBank([]);
     }
   }, [assessment, existingQuestions]);
@@ -116,6 +129,7 @@ export default function AssessmentForm({
         maxRetries: Number(maxRetries),
         timingMode,
         timeLimit: Number(timeLimit),
+        passMark: Number(passMark),
         course: courseId ? { id: courseId } : null, // null for standalone assessments
       };
 
@@ -421,6 +435,28 @@ export default function AssessmentForm({
                 retries allowed.
               </p>
             </div>
+
+            <div className={formGroupClass}>
+              <span htmlFor="pass-mark" className={labelClass}>
+                Pass Mark (%)
+              </span>
+              <input
+                id="pass-mark"
+                type="number"
+                value={passMark}
+                onChange={(e) =>
+                  setPassMark(Math.max(0, Math.min(100, Number(e.target.value))))
+                }
+                placeholder="e.g., 70"
+                min="0"
+                max="100"
+                step="0.1"
+                className={inputClass}
+              />
+              <p className="text-sm text-gray-500">
+                Minimum percentage score required to pass this assessment. Default: 70%
+              </p>
+            </div>
           </div>
 
           {/* Right Column */}
@@ -633,6 +669,7 @@ AssessmentForm.propTypes = {
     maxRetries: PropTypes.number,
     timingMode: PropTypes.oneOf(["none", "quiz", "question"]),
     timeLimit: PropTypes.number,
+    passMark: PropTypes.number,
     questionBank: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.string.isRequired,

--- a/src/private/pages/publicContent/online-courses/forms/assessment-form.js
+++ b/src/private/pages/publicContent/online-courses/forms/assessment-form.js
@@ -138,15 +138,43 @@ export default function AssessmentForm({
       // Save or update assessment
       if (assessment?.id) {
         // Edit existing assessment - only update assessment data, not questions
+        console.log("Updating assessment with data:", assessmentData);
+        console.log("Pass mark being saved:", assessmentData.passMark);
         const result = await updateAssessment({
           id: assessment.id,
           updates: assessmentData,
         }).unwrap();
-        savedAssessment = { ...assessment, ...result };
+        console.log("Assessment update response:", result);
+        console.log("Pass mark in response:", result.passMark);
+        
+        // Warn if passmark is not in the response (backend issue)
+        if (result.passMark === undefined || result.passMark === null) {
+          console.warn("⚠️ WARNING: Pass mark was sent but not returned in response. Backend may not be saving/returning passMark field.");
+          console.warn("Sent passMark:", assessmentData.passMark);
+          console.warn("Response keys:", Object.keys(result));
+          // Still include the passMark we sent in the saved assessment
+          savedAssessment = { ...assessment, ...result, passMark: assessmentData.passMark };
+        } else {
+          savedAssessment = { ...assessment, ...result };
+        }
       } else {
         // Create new assessment
+        console.log("Creating assessment with data:", assessmentData);
+        console.log("Pass mark being saved:", assessmentData.passMark);
         const result = await createAssessment(assessmentData).unwrap();
-        savedAssessment = result;
+        console.log("Assessment create response:", result);
+        console.log("Pass mark in response:", result.passMark);
+        
+        // Warn if passmark is not in the response (backend issue)
+        if (result.passMark === undefined || result.passMark === null) {
+          console.warn("⚠️ WARNING: Pass mark was sent but not returned in response. Backend may not be saving/returning passMark field.");
+          console.warn("Sent passMark:", assessmentData.passMark);
+          console.warn("Response keys:", Object.keys(result));
+          // Still include the passMark we sent in the saved assessment
+          savedAssessment = { ...result, passMark: assessmentData.passMark };
+        } else {
+          savedAssessment = result;
+        }
 
         // Only create questions for new assessments
         await Promise.all(
@@ -197,12 +225,27 @@ export default function AssessmentForm({
         );
       }
 
+      // Verify passmark was saved
+      if (savedAssessment.passMark === undefined || savedAssessment.passMark === null) {
+        console.warn("⚠️ Pass mark may not have been saved. Check backend implementation.");
+        // Show warning to user
+        setError("Assessment saved, but pass mark may not have been stored. Please verify in the database or contact support.");
+      }
+      
       // Call the parent onSave callback with the saved assessment
       onSave(savedAssessment);
     } catch (error) {
       console.error("Error saving assessment:", error);
+      console.error("Error details:", {
+        message: error?.data?.message || error?.message,
+        status: error?.status,
+        data: error?.data
+      });
       // Show error in UI instead of alert
-      setError("Error saving assessment. Please try again.");
+      const errorMessage = error?.data?.message 
+        || error?.message 
+        || "Error saving assessment. Please try again.";
+      setError(errorMessage);
     } finally {
       setIsSaving(false);
     }

--- a/src/private/pages/publicContent/online-courses/tabs/assessments-tab.js
+++ b/src/private/pages/publicContent/online-courses/tabs/assessments-tab.js
@@ -35,6 +35,7 @@ import {
   useDeleteAssessmentMutation,
   useGetQuizAttemptsByAssessmentQuery,
   useLazyGetQuizAttemptByIdQuery,
+  useRecalculateAssessmentAttemptsMutation,
 } from "../../../../../redux/apiSlice";
 
 export default function AssessmentsTab({
@@ -313,6 +314,7 @@ function AssessmentResultsPanel({ assessment, onClose }) {
   });
   const [fetchAttemptDetail] = useLazyGetQuizAttemptByIdQuery();
   const [awardMarks] = useAwardMarksForStructuredQuestionMutation();
+  const [recalculateAttempts, { isLoading: isRecalculating }] = useRecalculateAssessmentAttemptsMutation();
   const [attemptDetails, setAttemptDetails] = useState({});
   const [attemptDetailErrors, setAttemptDetailErrors] = useState({});
   const [loadingAttemptId, setLoadingAttemptId] = useState(null);
@@ -1965,10 +1967,22 @@ function AssessmentResultsPanel({ assessment, onClose }) {
                 </button>
                 <button
                   type="button"
-                  onClick={() => refetch()}
-                  className="text-sm text-blue-600 hover:text-blue-800 font-semibold"
+                  onClick={async () => {
+                    try {
+                      // First recalculate all attempts based on current pass mark and correct answers
+                      await recalculateAttempts(assessmentId).unwrap();
+                      // Then refetch the updated data
+                      await refetch();
+                    } catch (error) {
+                      console.error("Error recalculating attempts:", error);
+                      // Still try to refetch even if recalculation fails
+                      await refetch();
+                    }
+                  }}
+                  disabled={isRecalculating || isFetching}
+                  className="text-sm text-blue-600 hover:text-blue-800 font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  Refresh
+                  {isRecalculating ? "Recalculating..." : "Refresh"}
                 </button>
               </div>
             </div>

--- a/src/private/pages/publicContent/online-courses/tabs/assessments-tab.js
+++ b/src/private/pages/publicContent/online-courses/tabs/assessments-tab.js
@@ -26,6 +26,7 @@ import {
   Award,
 } from "lucide-react";
 import AssessmentForm from "../forms/assessment-form";
+import NotificationModal from "../../../../../components/NotificationModal";
 import {
   useGetAssessmentsByCourseQuery,
   useAwardMarksForStructuredQuestionMutation,
@@ -36,6 +37,7 @@ import {
   useGetQuizAttemptsByAssessmentQuery,
   useLazyGetQuizAttemptByIdQuery,
   useRecalculateAssessmentAttemptsMutation,
+  useGetAssessmentByIdQuery,
 } from "../../../../../redux/apiSlice";
 
 export default function AssessmentsTab({
@@ -312,9 +314,28 @@ function AssessmentResultsPanel({ assessment, onClose }) {
   } = useGetQuizAttemptsByAssessmentQuery(assessmentId, {
     skip: !assessmentId,
   });
+  // Fetch latest assessment data to get updated pass mark
+  const {
+    data: latestAssessment,
+    refetch: refetchAssessment,
+    isLoading: isLoadingAssessment,
+  } = useGetAssessmentByIdQuery(assessmentId, {
+    skip: !assessmentId,
+  });
+  
+  // Log assessment data changes for debugging
+  useEffect(() => {
+    if (latestAssessment) {
+      console.log("Latest assessment data loaded:", latestAssessment);
+      console.log("Pass mark from latest assessment:", latestAssessment.passMark);
+    }
+  }, [latestAssessment]);
   const [fetchAttemptDetail] = useLazyGetQuizAttemptByIdQuery();
   const [awardMarks] = useAwardMarksForStructuredQuestionMutation();
   const [recalculateAttempts, { isLoading: isRecalculating }] = useRecalculateAssessmentAttemptsMutation();
+  
+  // Use latest assessment data if available, otherwise fall back to prop
+  const currentAssessment = latestAssessment || assessment;
   const [attemptDetails, setAttemptDetails] = useState({});
   const [attemptDetailErrors, setAttemptDetailErrors] = useState({});
   const [loadingAttemptId, setLoadingAttemptId] = useState(null);
@@ -322,6 +343,7 @@ function AssessmentResultsPanel({ assessment, onClose }) {
   const [activeTab, setActiveTab] = useState("detailed"); // "detailed" or "summary"
   const [marksEditing, setMarksEditing] = useState({}); // Track which questions are being edited
   const [marksData, setMarksData] = useState({}); // Store marks input: { attemptId-questionId: { awarded: number, max: number } }
+  const [notification, setNotification] = useState({ isOpen: false, type: "success", message: "" });
 
   useEffect(() => {
     document.body.style.overflow = "hidden";
@@ -339,6 +361,9 @@ function AssessmentResultsPanel({ assessment, onClose }) {
   const attemptList = analyticsData?.attempts || [];
   const analytics = analyticsData || {};
 
+  // Get pass mark from latest assessment data, default to 70 if not available
+  const passMarkThreshold = currentAssessment?.passMark !== undefined ? currentAssessment.passMark : 70;
+
   // Calculate summarized performance (best attempt per user)
   const summarizedPerformance = useMemo(() => {
     const userBestAttempts = {};
@@ -351,6 +376,12 @@ function AssessmentResultsPanel({ assessment, onClose }) {
         !userBestAttempts[userId] ||
         percentage > userBestAttempts[userId].percentage
       ) {
+        // Use attempt.passed from backend if available (calculated with correct passMark),
+        // otherwise calculate using assessment's passMark
+        const passed = attempt.passed !== undefined 
+          ? attempt.passed 
+          : percentage >= passMarkThreshold;
+
         userBestAttempts[userId] = {
           participantId: userId,
           bestAttempt: attempt,
@@ -358,7 +389,7 @@ function AssessmentResultsPanel({ assessment, onClose }) {
           score: attempt.score,
           totalMarks: attempt.totalMarks || attempt.totalQuestions, // Use totalMarks if available, fallback to totalQuestions
           totalQuestions: attempt.totalQuestions,
-          passed: percentage >= 70, // Match report pass/fail threshold (70%)
+          passed: passed,
           completedAt: attempt.completedAt,
           attemptNumber: attempt.attemptNumber,
           totalAttempts: attemptList.filter((a) => a.participantId === userId)
@@ -370,7 +401,7 @@ function AssessmentResultsPanel({ assessment, onClose }) {
     return Object.values(userBestAttempts).sort(
       (a, b) => b.percentage - a.percentage
     );
-  }, [attemptList]);
+  }, [attemptList, passMarkThreshold]);
 
   // Export functions
   const exportToPDF = () => {
@@ -379,12 +410,12 @@ function AssessmentResultsPanel({ assessment, onClose }) {
     // Title
     doc.setFontSize(18);
     doc.setFont(undefined, "bold");
-    doc.text(`Assessment Results: ${assessment?.name || "Assessment"}`, 14, 20);
+    doc.text(`Assessment Results: ${currentAssessment?.name || "Assessment"}`, 14, 20);
 
     // Assessment info
     doc.setFontSize(12);
     doc.setFont(undefined, "normal");
-    doc.text(`Assessment: ${assessment?.name || "N/A"}`, 14, 35);
+    doc.text(`Assessment: ${currentAssessment?.name || "N/A"}`, 14, 35);
     doc.text(`Generated: ${new Date().toLocaleDateString()}`, 14, 45);
 
     // Statistics
@@ -470,7 +501,7 @@ function AssessmentResultsPanel({ assessment, onClose }) {
     const statsData = [
       ["Assessment Results Report"],
       [""],
-      ["Assessment:", assessment?.name || "N/A"],
+      ["Assessment:", currentAssessment?.name || "N/A"],
       ["Generated:", new Date().toLocaleDateString()],
       [""],
       ["Overall Statistics"],
@@ -534,7 +565,7 @@ function AssessmentResultsPanel({ assessment, onClose }) {
         attempt.score,
         attempt.totalQuestions,
         `${pct}%`,
-        pct >= 70 ? "Pass" : "Fail", // Match report pass/fail threshold (70%)
+        pct >= passMarkThreshold ? "Pass" : "Fail",
         new Date(attempt.startedAt).toLocaleString(),
         new Date(attempt.completedAt).toLocaleString(),
         attempt.durationMinutes || 0,
@@ -587,8 +618,11 @@ function AssessmentResultsPanel({ assessment, onClose }) {
         ? Math.round((attempt.score * 100) / attempt.totalQuestions)
         : 0;
       scoreSum += pct;
-      // Match report pass/fail threshold (70%)
-      if (pct >= 70) passCount += 1;
+      // Use attempt.passed from backend if available, otherwise calculate using assessment's passMark
+      const passed = attempt.passed !== undefined 
+        ? attempt.passed 
+        : pct >= passMarkThreshold;
+      if (passed) passCount += 1;
     });
     const avgScore = Math.round(scoreSum / attemptList.length);
     const passRate = Math.round((passCount / attemptList.length) * 100);
@@ -598,7 +632,7 @@ function AssessmentResultsPanel({ assessment, onClose }) {
       avgScore,
       passRate,
     };
-  }, [attemptList, analytics]);
+  }, [attemptList, analytics, passMarkThreshold]);
 
   const handleOverlayClick = (event) => {
     if (event.target === event.currentTarget) onClose();
@@ -667,11 +701,11 @@ function AssessmentResultsPanel({ assessment, onClose }) {
       questionPerformances.length > 0 ? questionPerformances : legacyAnswers;
 
     // Calculate report metrics (same as renderAssessmentReport)
-    // Prioritize attempt.totalQuestions, then assessment.questionCount, then answers.length
+    // Prioritize attempt.totalQuestions, then currentAssessment.questionCount, then answers.length
     // Ensure totalQuestions is a count (integer), not marks
     let totalQuestions =
       attempt.totalQuestions ||
-      assessment?.questionCount ||
+      currentAssessment?.questionCount ||
       answers.length ||
       0;
     // Validate: ensure it's a number and not accidentally maxMarks
@@ -773,7 +807,11 @@ function AssessmentResultsPanel({ assessment, onClose }) {
     const percentage =
       attempt.percentage ||
       (maxMarks > 0 ? Math.round((totalMarks / maxMarks) * 100) : 0);
-    const passFail = percentage >= 70 ? "Pass" : "Fail";
+    // Use attempt.passed from backend if available (calculated with correct passMark),
+    // otherwise calculate using assessment's passMark dynamically
+    const passFail = attempt.passed !== undefined
+      ? (attempt.passed ? "Pass" : "Fail")
+      : (percentage >= passMarkThreshold ? "Pass" : "Fail");
 
     const timeTaken = attempt.durationSeconds
       ? formatDuration(attempt.durationSeconds)
@@ -850,7 +888,7 @@ function AssessmentResultsPanel({ assessment, onClose }) {
     doc.setFontSize(12);
     doc.setFont("helvetica", "normal");
     doc.text(
-      `Scorecard | ${assessment.name} – ${attemptDate} (${attemptNumber}${
+      `Scorecard | ${currentAssessment.name} – ${attemptDate} (${attemptNumber}${
         attemptNumber === 1
           ? "st"
           : attemptNumber === 2
@@ -940,7 +978,7 @@ function AssessmentResultsPanel({ assessment, onClose }) {
     }
 
     // Save PDF
-    const fileName = `Assessment_Report_${assessment.name.replace(
+    const fileName = `Assessment_Report_${currentAssessment.name.replace(
       /\s+/g,
       "_"
     )}_${attempt.participantId}_${attemptNumber}.pdf`;
@@ -957,11 +995,11 @@ function AssessmentResultsPanel({ assessment, onClose }) {
       questionPerformances.length > 0 ? questionPerformances : legacyAnswers;
 
     // Calculate report metrics
-    // Prioritize attempt.totalQuestions, then assessment.questionCount, then answers.length
+    // Prioritize attempt.totalQuestions, then currentAssessment.questionCount, then answers.length
     // Ensure totalQuestions is a count (integer), not marks
     let totalQuestions =
       attempt.totalQuestions ||
-      assessment?.questionCount ||
+      currentAssessment?.questionCount ||
       answers.length ||
       0;
     // Validate: ensure it's a number and not accidentally maxMarks
@@ -1066,7 +1104,11 @@ function AssessmentResultsPanel({ assessment, onClose }) {
     const percentage =
       attempt.percentage ||
       (maxMarks > 0 ? Math.round((totalMarks / maxMarks) * 100) : 0);
-    const passFail = percentage >= 70 ? "Pass" : "Fail";
+    // Use attempt.passed from backend if available (calculated with correct passMark),
+    // otherwise calculate using assessment's passMark dynamically
+    const passFail = attempt.passed !== undefined
+      ? (attempt.passed ? "Pass" : "Fail")
+      : (percentage >= passMarkThreshold ? "Pass" : "Fail");
 
     const timeTaken = attempt.durationSeconds
       ? formatDuration(attempt.durationSeconds)
@@ -1113,7 +1155,7 @@ function AssessmentResultsPanel({ assessment, onClose }) {
                 ONLINE KNOWLEDGE/PROFICIENCY ASSESSMENT REPORT
               </h3>
               <p className="text-sm text-gray-600 mt-1 text-center">
-                Scorecard | {assessment.name} – {attemptDate} ({attemptNumber}
+                Scorecard | {currentAssessment.name} – {attemptDate} ({attemptNumber}
                 {attemptNumber === 1
                   ? "st"
                   : attemptNumber === 2
@@ -1969,20 +2011,100 @@ function AssessmentResultsPanel({ assessment, onClose }) {
                   type="button"
                   onClick={async () => {
                     try {
-                      // First recalculate all attempts based on current pass mark and correct answers
-                      await recalculateAttempts(assessmentId).unwrap();
-                      // Then refetch the updated data
+                      // First, refetch the latest assessment data to get updated pass mark
+                      console.log("Refreshing assessment data...");
+                      const assessmentResult = await refetchAssessment();
+                      console.log("Latest assessment data:", assessmentResult.data);
+                      console.log("Current pass mark:", assessmentResult.data?.passMark || passMarkThreshold);
+                      
+                      // Then recalculate all attempts based on current pass mark and correct answers
+                      // This will:
+                      // 1. Fetch new attempts that have been completed and submitted
+                      // 2. Update pass/fail status based on current pass mark (dynamically from database)
+                      // 3. Recalculate scores if questions were edited (correct answers changed or questions removed)
+                      console.log(`Calling recalculation endpoint: /quiz-attempts/assessment/${assessmentId}/recalculate`);
+                      const result = await recalculateAttempts(assessmentId).unwrap();
+                      console.log("Recalculation result:", result);
+                      
+                      // Clear expanded attempts so they reload with fresh data
+                      setExpandedAttemptId(null);
+                      setAttemptDetails({});
+                      
+                      // Then refetch the updated attempts data
                       await refetch();
+                      
+                      // Show success feedback
+                      if (result?.recalculatedAttempts > 0) {
+                        console.log(`Successfully recalculated ${result.recalculatedAttempts} attempt(s) with pass mark: ${passMarkThreshold}%`);
+                        setNotification({
+                          isOpen: true,
+                          type: "success",
+                          message: `Successfully refreshed results! ${result.recalculatedAttempts} attempt(s) recalculated.`,
+                        });
+                      } else {
+                        setNotification({
+                          isOpen: true,
+                          type: "success",
+                          message: "Results refreshed successfully. No attempts needed recalculation.",
+                        });
+                      }
                     } catch (error) {
                       console.error("Error recalculating attempts:", error);
-                      // Still try to refetch even if recalculation fails
-                      await refetch();
+                      console.error("Error details:", {
+                        status: error?.status,
+                        data: error?.data,
+                        originalStatus: error?.originalStatus,
+                        endpoint: `/quiz-attempts/assessment/${assessmentId}/recalculate`,
+                        fullError: error
+                      });
+                      
+                      // Check if it's a 404 - the endpoint might not exist on backend
+                      const is404 = error?.status === 404 || error?.originalStatus === 404;
+                      
+                      if (is404) {
+                        // If endpoint doesn't exist, just refresh the data without recalculation
+                        console.warn("Recalculation endpoint not found (404). Refreshing data without recalculation.");
+                        await refetch();
+                        await refetchAssessment();
+                        setNotification({
+                          isOpen: true,
+                          type: "info",
+                          message: `Results refreshed successfully.\n\nNote: The recalculation endpoint is not available on the backend. Pass/fail status updates may require backend implementation of the '/quiz-attempts/assessment/${assessmentId}/recalculate' endpoint.`,
+                        });
+                      } else {
+                        // For other errors, show error message
+                        const errorMessage = error?.data?.message 
+                          || error?.error 
+                          || (error?.status 
+                            ? `Server error (${error.status})`
+                            : "Unknown error");
+                        
+                        setNotification({
+                          isOpen: true,
+                          type: "error",
+                          message: `Failed to refresh results: ${errorMessage}\n\nNote: The refresh will still update the display with any new attempts, but recalculation failed.`,
+                        });
+                        // Still try to refetch even if recalculation fails to get any new attempts
+                        await refetch();
+                        await refetchAssessment();
+                      }
                     }
                   }}
                   disabled={isRecalculating || isFetching}
-                  className="text-sm text-blue-600 hover:text-blue-800 font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-blue-600 bg-white border border-blue-300 rounded-md hover:bg-blue-50 hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  title="Refresh results: Updates with new attempts, recalculates pass/fail based on current pass mark, and updates scores if questions were edited"
                 >
-                  {isRecalculating ? "Recalculating..." : "Refresh"}
+                  {isRecalculating ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Recalculating...
+                    </>
+                  ) : (
+                    <>
+                      <Loader2 className="h-4 w-4" />
+                      Refresh
+                    </>
+                  )}
                 </button>
               </div>
             </div>
@@ -2005,7 +2127,10 @@ function AssessmentResultsPanel({ assessment, onClose }) {
                   : attempt.totalQuestions
                   ? Math.round((attempt.score * 100) / attempt.totalQuestions)
                   : 0;
-                const passed = percent >= 70; // Match report pass/fail threshold (70%)
+                // Use attempt.passed from backend if available, otherwise calculate using assessment's passMark
+                const passed = attempt.passed !== undefined 
+                  ? attempt.passed 
+                  : percent >= passMarkThreshold;
                 const badgeClass = passed
                   ? "bg-emerald-50 text-emerald-700"
                   : "bg-rose-50 text-rose-700";
@@ -2214,11 +2339,11 @@ function AssessmentResultsPanel({ assessment, onClose }) {
               Assessment results
             </p>
             <h3 className="text-2xl font-bold text-gray-900">
-              {assessment?.name}
+              {currentAssessment?.name}
             </h3>
-            {assessment?.description && (
+            {currentAssessment?.description && (
               <p className="text-sm text-gray-500 mt-1 line-clamp-2">
-                {assessment.description}
+                {currentAssessment.description}
               </p>
             )}
           </div>
@@ -2233,6 +2358,12 @@ function AssessmentResultsPanel({ assessment, onClose }) {
         </div>
         <div className="flex-1 overflow-y-auto p-6">{bodyContent}</div>
       </div>
+      <NotificationModal
+        isOpen={notification.isOpen}
+        type={notification.type}
+        message={notification.message}
+        onClose={() => setNotification({ ...notification, isOpen: false })}
+      />
     </div>
   );
 }

--- a/src/redux/apiSlice.ts
+++ b/src/redux/apiSlice.ts
@@ -128,6 +128,23 @@ export const apiSlice = createApi({
         { type: "AssessmentResult", attemptId },
       ],
     }),
+    recalculateAssessmentAttempts: builder.mutation<
+      {
+        assessmentId: number;
+        assessmentName: string;
+        recalculatedAttempts: number;
+        totalAttempts: number;
+      },
+      number
+    >({
+      query: (assessmentId) => ({
+        url: `/quiz-attempts/assessment/${assessmentId}/recalculate`,
+        method: "POST",
+      }),
+      invalidatesTags: (result, error, assessmentId) => [
+        { type: "AssessmentResult", assessmentId },
+      ],
+    }),
     // Course endpoints
     getCourses: builder.query<Course[], void>({
       query: () => "/courses",
@@ -624,6 +641,7 @@ export const {
   useRecordQuizAnswerMutation,
   useFinishQuizAttemptMutation,
   useAwardMarksForStructuredQuestionMutation,
+  useRecalculateAssessmentAttemptsMutation,
   useGetUserQuizAttemptsQuery,
   useGetQuizAttemptsByAssessmentQuery,
   useGetQuizAttemptByIdQuery,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -119,6 +119,7 @@ export interface CourseAssessment {
   maxRetries: number;
   timingMode: "none" | "quiz" | "question";
   timeLimit: number; // in minutes for quiz mode, seconds for question mode
+  passMark: number; // Pass mark as percentage (e.g., 70 for 70%)
   status: number;
   createdAt: string;
   updatedAt: string;
@@ -202,6 +203,7 @@ export interface AssessmentFormData {
   maxRetries: number;
   timingMode: "none" | "quiz" | "question";
   timeLimit: number;
+  passMark: number; // Pass mark as percentage
   courseId?: number;
 }
 


### PR DESCRIPTION
In this PR, the following has been implemented.
- The admin can add and edit a pass mark on the assessment page

Enabled the refresh results button to handle the following:

- Update the results report with new attempts incase a user has completed and submitted assessments.
- Update marks pass/fail result incase pass mark is updated.
- Update score in case questions are edited (change of correct answer or incase some questions are removed from the assessment)